### PR TITLE
Add section and column information to LinkML as annotations

### DIFF
--- a/sheet2dataharmonizer/converters/commands.py
+++ b/sheet2dataharmonizer/converters/commands.py
@@ -138,7 +138,7 @@ def _inject_supplementary(
                 ann_list.append(ann)
             if 'column_order' in i:
                 tag_name = "dh:column_number"
-                ghsheet_header = 'column_number'
+                ghsheet_header = 'column_order'
                 val_name = i[ghsheet_header]
                 if not val_name:
                     logger.warning(f"The header {ghsheet_header} could not be found.")

--- a/sheet2dataharmonizer/converters/commands.py
+++ b/sheet2dataharmonizer/converters/commands.py
@@ -1,5 +1,4 @@
 import logging
-from threading import currentThread
 
 import click
 import click_log

--- a/sheet2dataharmonizer/converters/commands.py
+++ b/sheet2dataharmonizer/converters/commands.py
@@ -1,4 +1,5 @@
 import logging
+from threading import currentThread
 
 import click
 import click_log
@@ -9,6 +10,7 @@ from linkml_runtime.linkml_model import (
     Example,
     EnumDefinition,
     PermissibleValue,
+    Annotation
 )
 from linkml_runtime.utils.schemaview import SchemaView
 from linkml_runtime.dumpers import yaml_dumper
@@ -123,6 +125,30 @@ def _inject_supplementary(
             new_slot = SlotDefinition(
                 name=i_s, slot_uri=prefix + ":" + i_s, title=i["name"]
             )
+            
+            ann_list = []   # list of section, column pair annotations
+            if 'section' in i:
+                tag_name = "dh:section_name"
+                ghsheet_header = 'section'
+                val_name = i[ghsheet_header]
+                if not val_name:
+                    logger.warning(f"The header {ghsheet_header} could not be found.")
+                    val_name = "to_be_annotated"
+                ann = Annotation(tag=tag_name, value=val_name)
+                ann_list.append(ann)
+            if 'column_order' in i:
+                tag_name = "dh:column_number"
+                ghsheet_header = 'column_number'
+                val_name = i[ghsheet_header]
+                if not val_name:
+                    logger.warning(f"The header {ghsheet_header} could not be found.")
+                    val_name = "to_be_annotated"
+                ann = Annotation(tag=tag_name, value=val_name)
+                ann_list.append(ann)
+            
+            # assign list of annotations to slot's annotations attribute
+            new_slot.annotations = ann_list
+
             if i["requirement status"] == "required":
                 new_slot.required = True
             if i["requirement status"] == "recommended":
@@ -242,6 +268,7 @@ def sheet2linkml(
         "schema": "http://schema.org/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "UO": "http://purl.obolibrary.org/obo/UO_",
+        "dh": "https://github.com/cidgoh/DataHarmonizer/wiki"
     }
 
     new_schema = Sheet2LinkML.construct_schema(

--- a/sheet2dataharmonizer/converters/linkml2dataharmonizer.py
+++ b/sheet2dataharmonizer/converters/linkml2dataharmonizer.py
@@ -131,17 +131,14 @@ class LinkML2DataHarmonizer:
 
         for i in relevant_slots:
             # block that adds approporiate section names to the data.tsv
-            if i.is_a is None:
-                try:
-                    relevant_isa = i.annotations._get("dh:section_name").value
+            try:
+                relevant_isa = i.annotations._get("dh:section_name").value
 
-                    isa_dict[i.name] = relevant_isa
-                    isa_set.add(relevant_isa)
-                except AttributeError:
-                    logger.debug(f"No annotations associated with slot {i.name}")
-                    pass
-            else:
-                relevant_isa = "placeholder"
+                isa_dict[i.name] = relevant_isa
+                isa_set.add(relevant_isa)
+            except AttributeError:
+                logger.debug(f"No annotations associated with slot {i.name}")
+                pass
 
         if as_a == "set":
             return isa_set

--- a/sheet2dataharmonizer/converters/linkml2dataharmonizer.py
+++ b/sheet2dataharmonizer/converters/linkml2dataharmonizer.py
@@ -131,14 +131,13 @@ class LinkML2DataHarmonizer:
 
         for i in relevant_slots:
             # block that adds approporiate section names to the data.tsv
-            try:
+            if i.annotations:
                 relevant_isa = i.annotations._get("dh:section_name").value
+            else:
+                relevant_isa = i.is_a
 
-                isa_dict[i.name] = relevant_isa
-                isa_set.add(relevant_isa)
-            except AttributeError:
-                logger.debug(f"No annotations associated with slot {i.name}")
-                pass
+            isa_dict[i.name] = relevant_isa
+            isa_set.add(relevant_isa)
 
         if as_a == "set":
             return isa_set

--- a/sheet2dataharmonizer/converters/linkml2dataharmonizer.py
+++ b/sheet2dataharmonizer/converters/linkml2dataharmonizer.py
@@ -138,7 +138,7 @@ class LinkML2DataHarmonizer:
             else:
                 # what if the slot uri is a full uri, not a curie?
                 prefix_portion = i.slot_uri.split(":")[0] + ":"
-                # logger.info(f"saw the prefix {prefix_portion}")
+                logger.info(f"saw the prefix {prefix_portion}")
                 self.prefix_tally.append(prefix_portion)
 
             if i.is_a is None:
@@ -195,7 +195,7 @@ class LinkML2DataHarmonizer:
         model_enum_names.sort()
 
         for i in term_names:
-            # logger.info(f"processing {i}")
+            logger.info(f"processing {i}")
             current_row = blank_row.copy()
             current_sd = rs_dict[i]
 
@@ -305,7 +305,7 @@ class LinkML2DataHarmonizer:
                 # update this once the enums are built
                 if current_sd.multivalued:
                     current_row["datatype"] = "multiple"
-                    # logger.info(f"    {i} is multi-valued")
+                    logger.info(f"    {i} is multi-valued")
                 else:
                     current_row["datatype"] = "select"
 
@@ -369,7 +369,7 @@ class LinkML2DataHarmonizer:
                 current_row["requirement"] = "required"
 
             term_list.append(current_row)
-        # logger.info("\n")
+        logger.info("\n")
 
         return {"term": term_list, "pv": pv_list}
 


### PR DESCRIPTION
The code in this PR seeks to modify the `sheet2linkml.py` file in such a way that it generates a LinkML YAML file that stores the section name and column order information from the Google Sheet. The retrieved section and column information is stored as annotations associated with a LinkML model slot.