### PR TITLE
Import minified Handsontable CSS to suppress warnings in Vite apps

### DIFF
--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -24,7 +24,7 @@ import {
   validateValsAgainstVocab,
 } from './utils/validation';
 
-import 'handsontable/dist/handsontable.full.css';
+import 'handsontable/dist/handsontable.full.min.css';
 import './data-harmonizer.css';
 import '@selectize/selectize/dist/css/selectize.bootstrap4.css';
 


### PR DESCRIPTION
Fixes #203 
