### PR TITLE
Update sameple name guidance

### DIFF
--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -1428,7 +1428,9 @@ class DataHarmonizer {
       guidance.push(paragraph);
     }
     if (field.identifier) {
-      guidance.push('Each record must have a unique value (across all tabs) for this field.');
+      guidance.push(
+        'Each record must have a unique value (across all tabs) for this field.'
+      );
     }
     if (field.sources && field.sources.length) {
       let sources = [];

--- a/lib/DataHarmonizer.js
+++ b/lib/DataHarmonizer.js
@@ -1428,7 +1428,7 @@ class DataHarmonizer {
       guidance.push(paragraph);
     }
     if (field.identifier) {
-      guidance.push('Each record must have a unique value for this field.');
+      guidance.push('Each record must have a unique value (across all tabs) for this field.');
     }
     if (field.sources && field.sources.length) {
       let sources = [];


### PR DESCRIPTION
Updates the `sample name` guidance to indicate that sample name must be unique across all tabs in the Submission Portal